### PR TITLE
モバイル端末の場合は「パスワード付きでまとめる」ボタンのwidthを100%にするよう修正

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -149,7 +149,11 @@ chrome.storage.sync.get(['isEnable'], (result) => {
   const buttonText: HTMLElement = document.createElement('span');
   buttonText.textContent = 'パスワード付きでまとめる';
 
-  const buttonCssText: string = copyComputedCssText(buttonPackUp, ['width', 'inline-size', 'padding']) + 'padding: 5px;';
+  let buttonCssText: string = copyComputedCssText(buttonPackUp, ['width', 'inline-size', 'padding']) + 'padding: 5px;';
+  if (navigator.userAgent.match(/Mobile/)) {
+    buttonCssText += 'width:100%;';
+  }
+
   buttonPackUpWithPw.style.cssText = buttonCssText;
   buttonPackUpWithPw.appendChild(buttonText);
 


### PR DESCRIPTION
Resolve #17