### PR TITLE
Resolve: ポップアップ表示時のスイッチのアニメーション抑制をsetTimeout()で行わないようにする #27

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -84,12 +84,4 @@ window.addEventListener('load', async () => {
     settingInput.prepend(label);
     settingList!.appendChild(settingInput);
   }
-
-  // HACK: 直後にtransitionをオンにするとアニメーションしてしまうので、少し間を置く
-  const checkboxes = document.querySelectorAll('.input-row input[type="checkbox"]');
-  setTimeout(() => {
-    for (const checkbox of checkboxes) {
-      checkbox.parentElement!.className = 'checkbox checkbox-initialized';
-    }
-  }, 50);
 });

--- a/src/public/popup.css
+++ b/src/public/popup.css
@@ -57,6 +57,7 @@ body {
   display: flex;
   align-items: center;
   background-color: #aaa;
+  transition: 200ms ease;
 }
 
 .checkbox .checkbox__switch::before {
@@ -65,10 +66,6 @@ body {
   height: 24px;
   border-radius: 25px;
   background-color: #fff;
-}
-
-.checkbox.checkbox-initialized .checkbox__switch,
-.checkbox.checkbox-initialized .checkbox__switch::before {
   transition: 200ms ease;
 }
 


### PR DESCRIPTION
Closes #27
検証したところ現環境ではアニメーション抑制が不要になっていたため、処理を削除